### PR TITLE
[Chore] Add config file & log file in SASM directory for gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ web/static/plugins/sweetalert2-theme-bootstrap-4/
 web/static/plugins/tempusdominus-bootstrap-4/
 web/static/plugins/uplot/
 .python-version
+SASM/config/
+SASM/log/


### PR DESCRIPTION
## Overview
This pull request adds configuration and log files located in the `SASM` directory to the `.gitignore` file to prevent these files from being tracked by Git.

## Work Items
1. Added entries to the `.gitignore` file to ignore configuration (`.config`) and log (`.log`) files in the `SASM` directory.
2. Updated the project to ensure that these files are not accidentally committed to the repository.

## Change Logic

### Before
- Configuration and log files in the `SASM` directory were being tracked by Git, which could result in unnecessary clutter and potential exposure of sensitive information.

### After
- The `.gitignore` file now includes entries to ignore configuration and log files in the `SASM` directory, preventing them from being tracked or committed.

## Usage
No changes in the usage of the project. Developers should ensure that any configuration or log files in the `SASM` directory are correctly ignored and not included in commits.

## Other
No additional concerns or discussions.

---

## 개요
이 풀 리퀘스트는 `SASM` 디렉토리에 위치한 설정 파일과 로그 파일을 `.gitignore` 파일에 추가하여 이러한 파일들이 Git에 의해 추적되지 않도록 합니다.

## 작업사항
1. `.gitignore` 파일에 `SASM` 디렉토리의 설정 파일(`.config`)과 로그 파일(`.log`)을 무시하도록 항목을 추가했습니다.
2. 이러한 파일들이 리포지토리에 실수로 커밋되지 않도록 프로젝트를 업데이트했습니다.

## 변경로직

### 변경전
- `SASM` 디렉토리의 설정 파일과 로그 파일이 Git에 의해 추적되고 있어, 불필요한 파일이 리포지토리에 포함되거나 민감한 정보가 노출될 가능성이 있었습니다.

### 변경후
- 이제 `.gitignore` 파일에 `SASM` 디렉토리의 설정 파일과 로그 파일을 무시하도록 항목이 추가되어, 이러한 파일들이 추적되거나 커밋되지 않도록 방지합니다.

## 사용방법
프로젝트 사용 방법에는 변화가 없습니다. 개발자들은 `SASM` 디렉토리 내의 설정 파일이나 로그 파일이 올바르게 무시되고 커밋에 포함되지 않도록 주의해야 합니다.

## 기타
추가적인 우려 사항이나 논의할 사항은 없습니다.
