### PR TITLE
[Chore] Add tmp directory for gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ web/static/plugins/uplot/
 .python-version
 SASM/config/
 SASM/log/
+tmp/


### PR DESCRIPTION
## Overview
This pull request adds the `tmp` directory to the `.gitignore` file to prevent temporary files from being tracked by Git.

## Work Items
1. Added the `tmp/` directory to the `.gitignore` file to ensure all temporary files generated during development are not tracked by Git.
2. Updated the project settings to reflect this change, ensuring a cleaner repository.

## Change Logic

### Before
- The `tmp` directory and its contents were not ignored, leading to the possibility of temporary files being accidentally committed to the repository.

### After
- The `tmp` directory is now included in the `.gitignore` file, preventing any temporary files within this directory from being tracked or committed to the repository.

## Usage
No changes to the usage of the project. Developers should ensure that any files placed in the `tmp` directory are intended to be temporary and will not be included in commits.

## Other
No additional concerns or discussions.

---

## 개요
이 풀 리퀘스트는 `tmp` 디렉토리를 `.gitignore` 파일에 추가하여 임시 파일들이 Git에 의해 추적되지 않도록 합니다.

## 작업사항
1. `tmp/` 디렉토리를 `.gitignore` 파일에 추가하여, 개발 중에 생성된 모든 임시 파일이 Git에 의해 추적되지 않도록 했습니다.
2. 이러한 변경 사항을 반영하여 프로젝트 설정을 업데이트했습니다.

## 변경로직

### 변경전
- `tmp` 디렉토리와 그 안의 파일들이 무시되지 않아, 임시 파일들이 실수로 리포지토리에 커밋될 가능성이 있었습니다.

### 변경후
- 이제 `tmp` 디렉토리가 `.gitignore` 파일에 추가되어, 이 디렉토리 내의 임시 파일들이 추적되거나 커밋되지 않도록 방지합니다.

## 사용방법
프로젝트 사용 방법에는 변화가 없습니다. `tmp` 디렉토리에 있는 파일들은 임시 파일로 간주되어 커밋되지 않도록 주의해야 합니다.

## 기타
추가적인 우려 사항이나 논의할 사항은 없습니다.
