### PR TITLE
[Chore] Remove bin/*/ entry from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 __pycache__/
-bin/*/
+#bin/*/
 docs/
 .vscode
 data/pg/


### PR DESCRIPTION
## Overview
This pull request removes the `bin/*/` entry from the `.gitignore` file, allowing files in the `bin` directory to be tracked by Git.

## Work Items
1. Removed the `bin/*/` entry from the `.gitignore` file to ensure that files within the `bin` directory are no longer ignored by Git.
2. Updated the project to reflect this change, ensuring that files in the `bin` directory can be committed and tracked as needed.

## Change Logic

### Before
- The `bin/*/` directory and its subdirectories were ignored by Git, preventing any files within them from being tracked or committed.
  
### After
- The `bin/*/` entry has been removed from the `.gitignore` file, allowing files in the `bin` directory to be included in commits and tracked by the repository.

## Usage
Developers can now commit and track files within the `bin` directory. Ensure that any necessary files in this directory are correctly included in future commits.

## Other
No additional concerns or discussions.

---

## 개요
이 풀 리퀘스트는 `.gitignore` 파일에서 `bin/*/` 항목을 삭제하여, `bin` 디렉토리 내의 파일들이 Git에 의해 추적되도록 합니다.

## 작업사항
1. `.gitignore` 파일에서 `bin/*/` 항목을 삭제하여, `bin` 디렉토리 내의 파일들이 더 이상 Git에 의해 무시되지 않도록 했습니다.
2. 이 변경 사항을 반영하여 프로젝트를 업데이트했습니다.

## 변경로직

### 변경전
- `bin/*/` 디렉토리와 그 하위 디렉토리들이 Git에 의해 무시되어, 그 안의 파일들이 추적되거나 커밋되지 않았습니다.

### 변경후
- 이제 `.gitignore` 파일에서 `bin/*/` 항목이 삭제되어, `bin` 디렉토리 내의 파일들이 커밋에 포함되고 추적될 수 있습니다.

## 사용방법
이제 개발자들은 `bin` 디렉토리 내의 파일들을 커밋하고 추적할 수 있습니다. 필요한 파일들이 올바르게 커밋에 포함되도록 주의하세요.

## 기타
추가적인 우려 사항이나 논의할 사항은 없습니다.
